### PR TITLE
fix docs links to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ There are `dev`, `test` and `docs` options for installing dependencies for those
 
 ## Documentation
 
-Read [the documentation](https://kwinkunks.github.io/unmap), especially [the examples](https://kwinkunks.github.io/unmap/userguide/Unmap_data_from_an_image.html).
+Read [the documentation](https://scienxlab.github.io/unmap/), especially [the examples](https://scienxlab.github.io/unmap/userguide/Unmap_data_from_an_image.html).
 
 
 ## Contributing
 
-Take a look at [`CONTRIBUTING.md`](https://github.com/kwinkunks/unmap/blob/main/CONTRIBUTING.md).
+Take a look at [`CONTRIBUTING.md`](https://github.com/scienxlab/unmap/blob/main/CONTRIBUTING.md).
 
 
 ## Testing


### PR DESCRIPTION
Update documentation links in readme.

Also update the github actions badges?